### PR TITLE
refactor: use correct property for description

### DIFF
--- a/frontend/src/domains/notice/components/notice-form.tsx
+++ b/frontend/src/domains/notice/components/notice-form.tsx
@@ -86,7 +86,7 @@ export const NoticeForm: React.FC<Props> = ({
         sx={{ marginTop: '20px' }}
       />
       <TextField
-        {...register('content')}
+        {...register('description')}
         error={Boolean(errors.description)}
         helperText={errors.description?.message}
         type='text'

--- a/frontend/src/domains/notice/pages/add-notice-page.tsx
+++ b/frontend/src/domains/notice/pages/add-notice-page.tsx
@@ -16,7 +16,7 @@ import { NoticeForm } from '../components';
 
 const initialState: NoticeFormProps = {
   title: '',
-  content: '',
+  description: '',
   status: 0,
   recipientType: 'EV',
   recipientRole: 0,


### PR DESCRIPTION
- Property "content" was used in place of "description" in notice form